### PR TITLE
fix(member와 token id 수정): 각 테이블의 PK 혼란을 막기 위해 DB 상 컬럼명 수정

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/domain/Member.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/domain/Member.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="member_id")
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/org/example/goormssd/usermanagementbackend/domain/Token.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/domain/Token.java
@@ -13,11 +13,12 @@ import java.time.LocalDateTime;
 public class Token {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="token_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "customer_id", nullable = false)
-    private Member customer;
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member user;
 
     private String accessToken;
     private String refreshToken;


### PR DESCRIPTION


## 🔀 PR 제목
- [Fix] member와 token의 테이블 상 혼란을 막기 위해 컬럼명 수정(fix이긴 하지만 bug로 인한 수정이 아니어서 일단 branch feature로 잡았음)


---

## 📌 작업 내용 요약

- member와 token의 테이블 상 혼란을 막기 위해 컬럼명 수정


---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] ERD에 맞게 수정이 되었나요?
- [ ] 부적절한 데이터 타입이 선언되지 않았나요?


---

## 🔗 관련 이슈

- Closes #이슈번호(3과 4가 이미 closed)
- Related to #이슈번호
---

## 📎 기타 참고 사항
- ERD 수정 예정