### PR TITLE
Feature/signup

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/MemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/MemberController.java
@@ -3,6 +3,7 @@ package org.example.goormssd.usermanagementbackend.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.goormssd.usermanagementbackend.dto.request.EmailCheckRequestDto;
 import org.example.goormssd.usermanagementbackend.dto.request.SignupRequestDto;
 import org.example.goormssd.usermanagementbackend.service.MemberService;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -23,5 +27,21 @@ public class MemberController {
         // 회원 저장 및 이메일 인증 처리까지 서비스에서 수행
         memberService.signup(requestDto);
         return ResponseEntity.ok("회원가입이 완료되었습니다. 이메일을 확인해주세요.");
+    }
+
+    @PostMapping("/email")
+    public ResponseEntity<Map<String, Object>> checkEmailDuplicate(@RequestBody @Valid EmailCheckRequestDto requestDto) {
+        boolean exists = memberService.isEmailDuplicate(requestDto.getEmail());
+
+        Map<String, Object> response = new HashMap<>();
+        if (exists) {
+            response.put("status", 409);
+            response.put("message", "중복된 이메일입니다.");
+            return ResponseEntity.status(409).body(response);
+        } else {
+            response.put("status", 200);
+            response.put("message", "사용가능한 이메일입니다.");
+            return ResponseEntity.ok(response);
+        }
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/EmailCheckRequestDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/EmailCheckRequestDto.java
@@ -1,0 +1,15 @@
+package org.example.goormssd.usermanagementbackend.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EmailCheckRequestDto {
+
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -7,4 +7,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Integer> {
     Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/MemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/MemberService.java
@@ -21,6 +21,10 @@ public class MemberService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
+        if (memberRepository.existsByEmail(requestDto.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
 
@@ -42,5 +46,9 @@ public class MemberService {
         String code = emailVerificationService.createVerificationEntry(member);
         emailService.sendVerificationEmail(member.getEmail(), code);
 
+    }
+
+    public boolean isEmailDuplicate(String email) {
+        return memberRepository.existsByEmail(email);
     }
 }


### PR DESCRIPTION
## 🔀 PR 제목

 - [Feature] 회원가입 이메일 중복 확인 기능 구현

---

## 📌 작업 내용 요약

 - 이메일 중복 여부 확인을 위한 요청 DTO (EmailCheckRequestDto) 추가
 - 이메일 중복 검사 API (POST /api/auth/email) 구현
 - 중복 여부에 따라 상태 코드 및 메시지를 포함한 JSON 응답 반환
   - 사용 가능 시: 200 OK, "Email is available."
   - 중복된 경우: 409 Conflict, "Email is already in use."
   - DTO 없이 Map<String, Object> 기반으로 응답 처리하여 간단한 구조 유지

---

## ✅ 체크리스트

- [ ] 이메일 중복 검사를 위한 API를 구현했나요?
- [ ] 중복 여부에 따라 명확한 메시지를 반환하나요?
- [ ] 로컬 환경에서 API 요청/응답 테스트를 완료했나요?
- [ ] 기존 회원가입 흐름과 충돌되지 않도록 구성했나요?

---

## 🔗 관련 이슈

- Related to #6 #8 #31 

---

## 📎 기타 참고 사항
 - 프론트엔드에서 회원가입 시 이메일 입력란에 실시간 중복 확인 용도로 사용 가능
 - 추후 필요 시 동일한 방식으로 휴대폰 번호 중복 확인 API도 확장 가능
