### PR TITLE
feat(login_logout): login과 logout 기능 추가

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
@@ -1,0 +1,57 @@
+package org.example.goormssd.usermanagementbackend.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.goormssd.usermanagementbackend.dto.request.LoginRequestDto;
+import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.LoginResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.LoginUserDto;
+import org.example.goormssd.usermanagementbackend.service.AuthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Autowired
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/signin")
+    public ResponseEntity<ApiResponseDto<LoginResponseDto>> login(@RequestBody LoginRequestDto loginRequest, HttpServletResponse response) {
+        var result = authService.loginWithUserInfo(loginRequest);
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", result.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(60 * 60 * 24 * 7)
+                .sameSite("Strict")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        LoginResponseDto body = new LoginResponseDto(result.getAccessToken(), result.getUser());
+        ApiResponseDto<LoginResponseDto> apiResponse = new ApiResponseDto<>(200, "Login successful", body);
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @PostMapping("/signout")
+    public ResponseEntity<ApiResponseDto<Void>> logout(HttpServletRequest request) {
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.status(401).body(new ApiResponseDto<>(401, "Unauthorized", null));
+        }
+        String token = authHeader.substring(7);
+        authService.logout(token);
+        return ResponseEntity.ok(new ApiResponseDto<>(200, "Logout successful.", null));
+    }
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/LoginRequestDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/LoginRequestDto.java
@@ -1,0 +1,28 @@
+package org.example.goormssd.usermanagementbackend.dto.request;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequestDto {
+    private String email;
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/ApiResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/ApiResponseDto.java
@@ -1,0 +1,16 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponseDto<T> {
+    private int status;
+    private String message;
+    private T data;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/LoginResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/LoginResponseDto.java
@@ -1,0 +1,15 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponseDto {
+    private String accessToken;
+    private LoginUserDto user;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/LoginUserDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/LoginUserDto.java
@@ -1,0 +1,35 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.example.goormssd.usermanagementbackend.domain.Member;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginUserDto {
+    private Long id;
+    private String username;
+    private String email;
+    private String phoneNumber;
+    private String role;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public LoginUserDto(Member user) {
+        this.id = user.getId();
+        this.username = user.getUsername();
+        this.email = user.getEmail();
+        this.phoneNumber = user.getPhoneNumber();
+        this.role = user.getRole().name();
+        this.status = user.getStatus().name();
+        this.createdAt = user.getCreatedAt();
+        this.modifiedAt = user.getModifiedAt();
+    }
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AuthService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AuthService.java
@@ -1,0 +1,87 @@
+package org.example.goormssd.usermanagementbackend.service;
+
+import org.example.goormssd.usermanagementbackend.domain.Member;
+import org.example.goormssd.usermanagementbackend.domain.Token;
+import org.example.goormssd.usermanagementbackend.dto.request.LoginRequestDto;
+import org.example.goormssd.usermanagementbackend.dto.response.LoginUserDto;
+import org.example.goormssd.usermanagementbackend.repository.MemberRepository;
+import org.example.goormssd.usermanagementbackend.repository.TokenRepository;
+import org.example.goormssd.usermanagementbackend.util.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final TokenRepository tokenRepository;
+    private final TokenProvider tokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public AuthService(MemberRepository memberRepository,
+                       TokenRepository tokenRepository,
+                       TokenProvider tokenProvider,
+                       PasswordEncoder passwordEncoder) {
+        this.memberRepository = memberRepository;
+        this.tokenRepository = tokenRepository;
+        this.tokenProvider = tokenProvider;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public class LoginResult {
+        private String accessToken;
+        private String refreshToken;
+        private LoginUserDto user;
+
+        public LoginResult(String accessToken, String refreshToken, LoginUserDto user) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+            this.user = user;
+        }
+
+        public String getAccessToken() {
+            return accessToken;
+        }
+
+        public String getRefreshToken() {
+            return refreshToken;
+        }
+
+        public LoginUserDto getUser() {
+            return user;
+        }
+    }
+
+    public LoginResult loginWithUserInfo(LoginRequestDto loginRequest) {
+        Member user = memberRepository.findByEmail(loginRequest.getEmail())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            throw new RuntimeException("비밀번호가 올바르지 않습니다.");
+        }
+
+        String accessToken = tokenProvider.generateAccessToken(user.getEmail());
+        String refreshToken = tokenProvider.generateRefreshToken(user.getEmail());
+
+        Token token = new Token();
+        token.setUser(user);
+        token.setAccessToken(accessToken);
+        token.setRefreshToken(refreshToken);
+        token.setDeletedAt(null);
+
+        tokenRepository.save(token);
+
+        return new LoginResult(accessToken, refreshToken, new LoginUserDto(user));
+    }
+
+    public void logout(String accessToken) {
+        Token token = tokenRepository.findByAccessToken(accessToken)
+                .orElseThrow(() -> new RuntimeException("토큰을 찾을 수 없습니다."));
+        token.setDeletedAt(LocalDateTime.now());
+        tokenRepository.save(token);
+    }
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/util/TokenProvider.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/util/TokenProvider.java
@@ -1,0 +1,30 @@
+package org.example.goormssd.usermanagementbackend.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenProvider {
+
+    private final JwtUtil jwtUtil;
+
+    public TokenProvider(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    public String generateAccessToken(String email) {
+        return jwtUtil.generateToken(email);
+    }
+
+    public String generateRefreshToken(String email) {
+        // Implement refresh token generation logic
+        return jwtUtil.generateToken(email); // Placeholder
+    }
+
+    public boolean validateToken(String token) {
+        return jwtUtil.validateToken(token);
+    }
+
+    public String extractEmail(String token) {
+        return jwtUtil.extractEmail(token);
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 로그인, 로그아웃 기능 구현  


---

## 📌 작업 내용 요약
- 로그인과 로그아웃 기능 구현
- 로그인 요청 시 JWT 토큰 발급 및 저장
- 로그인 실패 시 에러 메시지 출력 처리


---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 회원가입된 계정을 바탕으로 로그인시 제대로 작동하나요?
- [ ] 로그아웃이 제대로 작동하나요?


---

## 🔗 관련 이슈

- Closes #9 
- Related to #9 
---

## 📎 기타 참고 사항
- DB에 그대로 넣고 테스트를 진행하면 member가 있음에도 사용자 정보가 없다고 나올 수 있음
- 직접 회원가입해서 DB에 집어 넣은 뒤 로그인과 로그아웃 진행 필요