### PR TITLE
Refactor/login logout

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/config/SecurityConfig.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package org.example.goormssd.usermanagementbackend.config;
 
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.util.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,13 +17,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtFilter;
-
-    public SecurityConfig(JwtAuthenticationFilter jwtFilter) {
-        this.jwtFilter = jwtFilter;
-    }
+//
+//    public SecurityConfig(JwtAuthenticationFilter jwtFilter) {
+//        this.jwtFilter = jwtFilter;
+//    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -37,6 +39,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/signout").authenticated()  // 로그아웃은 인증 필요
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/api/users/**").hasAnyRole("USER", "ADMIN")
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.goormssd.usermanagementbackend.dto.request.LoginRequestDto;
 import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.LoginResponseDto;
@@ -16,6 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api") // API 버전 관리
 @RequiredArgsConstructor // Lombok, final 이나 @NonNull 필드에 대해 생성자 자동 생성
@@ -30,8 +32,10 @@ public class AuthController {
     //        this.authService = authService;
     //    }
 
-    @PostMapping("/auth/signin") // 로그인 엔드포인트
-    public ResponseEntity<ApiResponseDto<LoginResponseDto>> login(@RequestBody LoginRequestDto loginRequest, HttpServletResponse response) {
+    @PostMapping("/auth/signin")
+    public ResponseEntity<ApiResponseDto<LoginResponseDto>> login(
+            @RequestBody LoginRequestDto loginRequest,
+            HttpServletResponse response) {
 
         // var 사용을 통해 타입 추론을 활용할 수 있지만, 명시적인 타입 선언이 가독성에 더 좋을 수 있음
         // 팀 프로젝트에서의 중요한 로직에서는 var 사용을 지양하고, 타입을 명시하는게 좋을 수 있음
@@ -77,34 +81,36 @@ public class AuthController {
 //        String accessToken = authHeader.substring(7);
 //        authService.logout(accessToken);
 
-        // 모든 쿠키 출력 (디버깅)
+        // 디버깅용: 모든 쿠키 로깅
         if (request.getCookies() != null) {
             for (Cookie c : request.getCookies()) {
-                System.out.println("[쿠키] " + c.getName() + " = " + c.getValue());
+                log.debug("[쿠키] {} = {}", c.getName(), c.getValue());
             }
         } else {
-            System.out.println("[쿠키] 없음");
+            log.debug("[쿠키] 없음");
         }
 
-        // 쿠키에서 refreshToken 추출 (파싱 개선)
+        // 쿠키에서 refreshToken 추출
         String refreshToken = null;
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
                 if ("refreshToken".equalsIgnoreCase(cookie.getName().trim())) {
                     refreshToken = cookie.getValue();
-                    System.out.println("[로그아웃] refreshToken 추출: " + refreshToken);
+                    log.debug("[로그아웃] refreshToken 추출: {}", refreshToken);
                     break;
                 }
             }
         }
 
-        // refreshToken이 존재하면 DB에서 삭제 처리
+
+        // refreshToken 있으면 서비스에 전달하여 DB 삭제
         if (refreshToken != null && !refreshToken.isBlank()) {
             authService.logout(refreshToken);
-            System.out.println("[로그아웃] 서비스에 refreshToken 전달 완료");
+            log.info("[로그아웃] 서비스에 refreshToken 전달 완료");
         } else {
-            System.out.println("[로그아웃] refreshToken이 전달되지 않음");
+            log.warn("[로그아웃] refreshToken이 전달되지 않음");
         }
+
 
         // 클라이언트에 저장된 RefreshToken 제거
         // api 명세에 써있지 않은 부분 로그아웃 시에는 RefreshToken을 제거 해야할 필요가 있음

--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
@@ -13,8 +13,6 @@ import org.example.goormssd.usermanagementbackend.service.dto.LoginResult;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j

--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
@@ -1,32 +1,42 @@
 package org.example.goormssd.usermanagementbackend.controller;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.dto.request.LoginRequestDto;
 import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.LoginResponseDto;
-import org.example.goormssd.usermanagementbackend.dto.response.LoginUserDto;
 import org.example.goormssd.usermanagementbackend.service.AuthService;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.example.goormssd.usermanagementbackend.service.dto.LoginResult;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api") // API 버전 관리
+@RequiredArgsConstructor // Lombok, final 이나 @NonNull 필드에 대해 생성자 자동 생성
 public class AuthController {
 
     private final AuthService authService;
 
-    @Autowired
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
+    // @RequiredArgsConstructor를 사용하면 @Autowired가 필요없음
+    // 가독성과 코드 간결성을 위해 @RequiredArgsConstructor를 사용하는 뱡향이 나아보임
+    //    @Autowired
+    //    public AuthController(AuthService authService) {
+    //        this.authService = authService;
+    //    }
 
-    @PostMapping("/signin")
+    @PostMapping("/auth/signin") // 로그인 엔드포인트
     public ResponseEntity<ApiResponseDto<LoginResponseDto>> login(@RequestBody LoginRequestDto loginRequest, HttpServletResponse response) {
-        var result = authService.loginWithUserInfo(loginRequest);
+
+        // var 사용을 통해 타입 추론을 활용할 수 있지만, 명시적인 타입 선언이 가독성에 더 좋을 수 있음
+        // 팀 프로젝트에서의 중요한 로직에서는 var 사용을 지양하고, 타입을 명시하는게 좋을 수 있음
+        // var LogingResult result = authService.loginWithUserInfo(loginRequest);
+        LoginResult result = authService.loginWithUserInfo(loginRequest);
 
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", result.getRefreshToken())
                 .httpOnly(true)
@@ -35,23 +45,78 @@ public class AuthController {
                 .maxAge(60 * 60 * 24 * 7)
                 .sameSite("Strict")
                 .build();
-
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        LoginResponseDto body = new LoginResponseDto(result.getAccessToken(), result.getUser());
-        ApiResponseDto<LoginResponseDto> apiResponse = new ApiResponseDto<>(200, "Login successful", body);
+//
+//        LoginResponseDto body = new LoginResponseDto(result.getAccessToken(), result.getUser());
+//        ApiResponseDto<LoginResponseDto> apiResponse = new ApiResponseDto<>(200, "Login successful", body);
+//
+//        return ResponseEntity.ok(apiResponse);
 
-        return ResponseEntity.ok(apiResponse);
+        LoginResponseDto responseBody = new LoginResponseDto(result.getAccessToken(), result.getUser());
+
+        return ResponseEntity.ok(
+                new ApiResponseDto<>(200, "Login successful", responseBody)
+        );
     }
 
     @PostMapping("/signout")
-    public ResponseEntity<ApiResponseDto<Void>> logout(HttpServletRequest request) {
-        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            return ResponseEntity.status(401).body(new ApiResponseDto<>(401, "Unauthorized", null));
+    public ResponseEntity<ApiResponseDto<Void>> logout(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+
+//        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+//        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+//            return ResponseEntity.status(401).body(new ApiResponseDto<>(401, "Unauthorized", null));
+//        }
+
+// 변수명 accessToken을 사용하여 가독성을 높임
+//        String token = authHeader.substring(7);
+//        authService.logout(token);
+//        String accessToken = authHeader.substring(7);
+//        authService.logout(accessToken);
+
+        // 모든 쿠키 출력 (디버깅)
+        if (request.getCookies() != null) {
+            for (Cookie c : request.getCookies()) {
+                System.out.println("[쿠키] " + c.getName() + " = " + c.getValue());
+            }
+        } else {
+            System.out.println("[쿠키] 없음");
         }
-        String token = authHeader.substring(7);
-        authService.logout(token);
+
+        // 쿠키에서 refreshToken 추출 (파싱 개선)
+        String refreshToken = null;
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("refreshToken".equalsIgnoreCase(cookie.getName().trim())) {
+                    refreshToken = cookie.getValue();
+                    System.out.println("[로그아웃] refreshToken 추출: " + refreshToken);
+                    break;
+                }
+            }
+        }
+
+        // refreshToken이 존재하면 DB에서 삭제 처리
+        if (refreshToken != null && !refreshToken.isBlank()) {
+            authService.logout(refreshToken);
+            System.out.println("[로그아웃] 서비스에 refreshToken 전달 완료");
+        } else {
+            System.out.println("[로그아웃] refreshToken이 전달되지 않음");
+        }
+
+        // 클라이언트에 저장된 RefreshToken 제거
+        // api 명세에 써있지 않은 부분 로그아웃 시에는 RefreshToken을 제거 해야할 필요가 있음
+        ResponseCookie expiredCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie.toString());
+
         return ResponseEntity.ok(new ApiResponseDto<>(200, "Logout successful.", null));
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/domain/Token.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/domain/Token.java
@@ -2,11 +2,16 @@ package org.example.goormssd.usermanagementbackend.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "token")
+// 테이블 이름은 DB에 따라 예약어일 경우가 있어 접두사 tbl_를 붙임
+@Table(name = "tbl_token")
+// Soft Delete 관리
+// @SQLDelete 애노테이션을 활용하면 자동으로 deletedAt IS NULL 조건을 걸어줄 수 있음
+@SQLDelete(sql = "UPDATE tbl_token SET deleted_at = CURRENT_TIMESTAMP WHERE token_id = ?")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,15 +23,17 @@ public class Token {
     @Column(name="token_id")
     private Long id;
 
+    // 필드명 통일 user -> member
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
-    private Member user;
+    private Member member;
 
-//    private String accessToken;
+    // private String accessToken;
     // AccessToken은 별도로 저장하지 않고, JWT로 생성하여 클라이언트에 전달
     // refreshToken민 DB에 저장하여 관리
-    @Column(nullable = false, unique = true)
+    @Column(name = "refresh_token", nullable = false, unique = true)
     private String refreshToken;
 
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/domain/Token.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/domain/Token.java
@@ -1,8 +1,7 @@
 package org.example.goormssd.usermanagementbackend.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -10,6 +9,9 @@ import java.time.LocalDateTime;
 @Table(name = "token")
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Token {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,7 +22,11 @@ public class Token {
     @JoinColumn(name = "member_id", nullable = false)
     private Member user;
 
-    private String accessToken;
+//    private String accessToken;
+    // AccessToken은 별도로 저장하지 않고, JWT로 생성하여 클라이언트에 전달
+    // refreshToken민 DB에 저장하여 관리
+    @Column(nullable = false, unique = true)
     private String refreshToken;
+
     private LocalDateTime deletedAt;
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/LoginRequestDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/LoginRequestDto.java
@@ -1,28 +1,51 @@
 package org.example.goormssd.usermanagementbackend.dto.request;
 
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.example.goormssd.usermanagementbackend.util.NoTripleRepeat;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class LoginRequestDto {
+
+    @NotBlank(message = "이메일은 필수 입력입니다.")
+    @Email(message = "유효한 이메일 형식을 입력해주세요.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+            message = "비밀번호는 대소문자, 숫자, 특수문자를 포함해야 합니다."
+    )
+    @NoTripleRepeat
     private String password;
 
-    public String getEmail() {
-        return email;
-    }
 
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
+    // Lombok을 사용하여 생성자, getter, setter 자동 생성
+    // 없어도 되는 부분
+//    public String getEmail() {
+//        return email;
+//    }
+//
+//    public void setEmail(String email) {
+//        this.email = email;
+//    }
+//
+//    public String getPassword() {
+//        return password;
+//    }
+//
+//    public void setPassword(String password) {
+//        this.password = password;
+//    }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/SignupRequestDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/SignupRequestDto.java
@@ -12,14 +12,14 @@ import org.example.goormssd.usermanagementbackend.util.NoTripleRepeat;
 @Setter
 public class SignupRequestDto {
 
-    @NotBlank
+    @NotBlank(message = "사용자 이름은 필수 입력입니다.")
     private String username;
 
-    @NotBlank
-    @Email
+    @NotBlank(message = "이메일은 필수 입력입니다.")
+    @Email(message = "유효한 이메일 형식을 입력해주세요.")
     private String email;
 
-    @NotBlank
+    @NotBlank(message = "비밀번호는 필수 입력입니다.")
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     @Pattern(
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
@@ -28,10 +28,10 @@ public class SignupRequestDto {
     @NoTripleRepeat
     private String password;
 
-    @NotBlank
+    @NotBlank(message = "비밀번호 확인은 필수 입력입니다.")
     private String passwordCheck;
 
-    @NotBlank
+    @NotBlank(message = "휴대폰 번호는 필수 입력입니다.")
     private String phoneNumber;
 
 

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/RefreshTokenDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/RefreshTokenDto.java
@@ -1,0 +1,11 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshTokenDto {
+    private final String accessToken;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/EmailVerificationRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/EmailVerificationRepository.java
@@ -2,10 +2,12 @@ package org.example.goormssd.usermanagementbackend.repository;
 
 import org.example.goormssd.usermanagementbackend.domain.EmailVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 
+@Repository
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
     Optional<EmailVerification> findByCode(String code);
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -2,9 +2,11 @@ package org.example.goormssd.usermanagementbackend.repository;
 
 import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Integer> {
     Optional<Member> findByEmail(String email);
 

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/PhoneVerificationRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/PhoneVerificationRepository.java
@@ -2,6 +2,8 @@ package org.example.goormssd.usermanagementbackend.repository;
 
 import org.example.goormssd.usermanagementbackend.domain.PhoneVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PhoneVerificationRepository extends JpaRepository<PhoneVerification, String> {
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/TokenRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/TokenRepository.java
@@ -1,7 +1,6 @@
 package org.example.goormssd.usermanagementbackend.repository;
 
 import org.example.goormssd.usermanagementbackend.domain.Token;
-import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/TokenRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/TokenRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface TokenRepository extends JpaRepository<Token, Integer> {
-    Optional<Token> findByAccessToken(String accessToken);
-    Optional<Token> findByRefreshToken(String refreshToken);
+public interface TokenRepository extends JpaRepository<Token, Long> {
+//    Optional<Token> findByAccessToken(String accessToken);
+
+    // RefreshToken을 통해 유효한 토큰만 찾기 (deletedAt이 null인 경우)
+    Optional<Token> findByRefreshTokenAndDeletedAtIsNull(String refreshToken);
+
 //    void deleteAllByCustomer(Member member);
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/TokenRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/TokenRepository.java
@@ -3,9 +3,11 @@ package org.example.goormssd.usermanagementbackend.repository;
 import org.example.goormssd.usermanagementbackend.domain.Token;
 import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface TokenRepository extends JpaRepository<Token, Long> {
 //    Optional<Token> findByAccessToken(String accessToken);
 

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AuthService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AuthService.java
@@ -122,4 +122,12 @@ public class AuthService {
                     tokenRepository.save(token);
                 });
     }
+
+    //전달된 refreshToken이 DB에 남아있고 deletedAt이 null인지 확인
+    public boolean isValidRefreshToken(String refreshToken) {
+        return tokenRepository
+                .findByRefreshTokenAndDeletedAtIsNull(refreshToken)
+                .isPresent();
+    }
+
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AuthService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AuthService.java
@@ -1,12 +1,15 @@
 package org.example.goormssd.usermanagementbackend.service;
 
+import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.example.goormssd.usermanagementbackend.domain.Token;
 import org.example.goormssd.usermanagementbackend.dto.request.LoginRequestDto;
 import org.example.goormssd.usermanagementbackend.dto.response.LoginUserDto;
 import org.example.goormssd.usermanagementbackend.repository.MemberRepository;
 import org.example.goormssd.usermanagementbackend.repository.TokenRepository;
-import org.example.goormssd.usermanagementbackend.util.TokenProvider;
+import org.example.goormssd.usermanagementbackend.service.dto.LoginResult;
+import org.example.goormssd.usermanagementbackend.util.JwtUtil;
+//import org.example.goormssd.usermanagementbackend.util.TokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,47 +17,55 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 
 @Service
+@RequiredArgsConstructor
 public class AuthService {
 
     private final MemberRepository memberRepository;
     private final TokenRepository tokenRepository;
-    private final TokenProvider tokenProvider;
+    // TokenProvider 삭제 검토
+//    private final TokenProvider tokenProvider;
+    private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
 
-    @Autowired
-    public AuthService(MemberRepository memberRepository,
-                       TokenRepository tokenRepository,
-                       TokenProvider tokenProvider,
-                       PasswordEncoder passwordEncoder) {
-        this.memberRepository = memberRepository;
-        this.tokenRepository = tokenRepository;
-        this.tokenProvider = tokenProvider;
-        this.passwordEncoder = passwordEncoder;
-    }
+    // AuthController에서와 동일한 이유로 생성자 주입 방식 사용
+//    @Autowired
+//    public AuthService(MemberRepository memberRepository,
+//                       TokenRepository tokenRepository,
+//                       TokenProvider tokenProvider,
+//                       PasswordEncoder passwordEncoder) {
+//        this.memberRepository = memberRepository;
+//        this.tokenRepository = tokenRepository;
+//        this.tokenProvider = tokenProvider;
+//        this.passwordEncoder = passwordEncoder;
+//    }
 
-    public class LoginResult {
-        private String accessToken;
-        private String refreshToken;
-        private LoginUserDto user;
-
-        public LoginResult(String accessToken, String refreshToken, LoginUserDto user) {
-            this.accessToken = accessToken;
-            this.refreshToken = refreshToken;
-            this.user = user;
-        }
-
-        public String getAccessToken() {
-            return accessToken;
-        }
-
-        public String getRefreshToken() {
-            return refreshToken;
-        }
-
-        public LoginUserDto getUser() {
-            return user;
-        }
-    }
+    // service layer에서 로그인 결과를 DTO로 반환하는 방식으로 변경
+    // service/dto/LoginResult.java
+    // 단일 책임 원칙(SRP) -> 서비스는 비즈니스 로직만 처리하고, DTO는 데이터 전송을 담당하도록 분리
+    // 구조적, 협업적, 유지보수적 측면에서 훨씬 바람직
+//    public class LoginResult {
+//        private String accessToken;
+//        private String refreshToken;
+//        private LoginUserDto user;
+//
+//        public LoginResult(String accessToken, String refreshToken, LoginUserDto user) {
+//            this.accessToken = accessToken;
+//            this.refreshToken = refreshToken;
+//            this.user = user;
+//        }
+//
+//        public String getAccessToken() {
+//            return accessToken;
+//        }
+//
+//        public String getRefreshToken() {
+//            return refreshToken;
+//        }
+//
+//        public LoginUserDto getUser() {
+//            return user;
+//        }
+//    }
 
     public LoginResult loginWithUserInfo(LoginRequestDto loginRequest) {
         Member user = memberRepository.findByEmail(loginRequest.getEmail())
@@ -64,12 +75,16 @@ public class AuthService {
             throw new RuntimeException("비밀번호가 올바르지 않습니다.");
         }
 
-        String accessToken = tokenProvider.generateAccessToken(user.getEmail());
-        String refreshToken = tokenProvider.generateRefreshToken(user.getEmail());
+        // AccessToken은 클라이언트가 저장 (서버 저장 불필요)
+        // DB에는 RefreshToken만 저장 (보안 이슈 최소화)
+        // 아직 명확한 해답을 찾지 못했음..
+        // 일단 코드적으로 AccessToken은 저장하지 않는 로직을 변경
+        String accessToken = jwtUtil.generateAccessToken(user.getEmail());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getEmail());
 
         Token token = new Token();
         token.setUser(user);
-        token.setAccessToken(accessToken);
+//        token.setAccessToken(accessToken);
         token.setRefreshToken(refreshToken);
         token.setDeletedAt(null);
 
@@ -78,10 +93,23 @@ public class AuthService {
         return new LoginResult(accessToken, refreshToken, new LoginUserDto(user));
     }
 
-    public void logout(String accessToken) {
-        Token token = tokenRepository.findByAccessToken(accessToken)
-                .orElseThrow(() -> new RuntimeException("토큰을 찾을 수 없습니다."));
-        token.setDeletedAt(LocalDateTime.now());
-        tokenRepository.save(token);
+//    public void logout(String accessToken) {
+//        Token token = tokenRepository.findByAccessToken(accessToken)
+//                .orElseThrow(() -> new RuntimeException("토큰을 찾을 수 없습니다."));
+//        token.setDeletedAt(LocalDateTime.now());
+//        tokenRepository.save(token);
+//    }
+
+    // 로그아웃
+    // 전달된 refreshToken을 통해 DB에서 해당 토큰을 찾아 삭제 처리
+    // 존재하고 아직 만료되지 않은 경우, 삭제 시간(deletedAt) 업데이트
+    // 클라이언트 측에서는 refreshToken이 삭제되므로 세션 종료 (자동 로그아웃)
+    public void logout(String refreshToken) {
+        // 아직 삭제되지 않은(refreshToken + deletedAt = null) 토큰을 DB에서 조회
+        tokenRepository.findByRefreshTokenAndDeletedAtIsNull(refreshToken)
+                .ifPresent(token -> {
+                    token.setDeletedAt(LocalDateTime.now());
+                    tokenRepository.save(token);
+                });
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AuthService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AuthService.java
@@ -77,11 +77,11 @@ public class AuthService {
             throw new RuntimeException("비밀번호가 올바르지 않습니다.");
         }
 
-        if (!member.isEmailVerified()) {
-            throw new ResponseStatusException(
-                    HttpStatus.FORBIDDEN, "이메일 인증을 완료해야 로그인할 수 있습니다."
-            );
-        }
+//        if (!member.isEmailVerified()) {
+//            throw new ResponseStatusException(
+//                    HttpStatus.FORBIDDEN, "이메일 인증을 완료해야 로그인할 수 있습니다."
+//            );
+//        }
 
         // AccessToken은 클라이언트가 저장 (서버 저장 불필요)
         // DB에는 RefreshToken만 저장 (보안 이슈 최소화)
@@ -135,9 +135,9 @@ public class AuthService {
     public boolean isValidRefreshToken(String refreshToken) {
         return tokenRepository
                 .findByRefreshTokenAndDeletedAtIsNull(refreshToken)
-                .map(token -> token.getMember())                // 토큰 소유자(Member) 조회
-                .filter(member -> member.isEmailVerified())    // 이메일 인증 여부 체크
-                .filter(member -> member.getStatus().isActive()) // 계정 상태(ACTIVE) 체크
+//                .map(token -> token.getMember())                // 토큰 소유자(Member) 조회
+//                .filter(member -> member.isEmailVerified())    // 이메일 인증 여부 체크
+//                .filter(member -> member.getStatus().isActive()) // 계정 상태(ACTIVE) 체크
                 .isPresent();
     }
 

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/CustomUserDetailsService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/CustomUserDetailsService.java
@@ -1,5 +1,7 @@
 package org.example.goormssd.usermanagementbackend.service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.example.goormssd.usermanagementbackend.repository.MemberRepository;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -10,27 +12,30 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
+@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
 
-    public CustomUserDetailsService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
-
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> {
+                    log.warn("User not found: {}", email);
+                    return new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
+                });
 
         // "ROLE_" 접두어는 Spring Security 권한 필수 형식
         String roleName = "ROLE_" + member.getRole().name();
+        log.debug("Assign role {} to user {}", roleName, email);
 
-        return new org.springframework.security.core.userdetails.User(
-                member.getEmail(),
-                member.getPassword(),
-                List.of(new SimpleGrantedAuthority(roleName))
-        );
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(member.getEmail())
+                .password(member.getPassword())
+                .authorities(List.of(new SimpleGrantedAuthority(roleName)))
+                .build();
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/dto/LoginResult.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/dto/LoginResult.java
@@ -1,0 +1,20 @@
+package org.example.goormssd.usermanagementbackend.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.goormssd.usermanagementbackend.dto.response.LoginUserDto;
+
+
+@Getter
+@AllArgsConstructor
+public class LoginResult {
+    private final String accessToken;
+    private final String refreshToken;
+    private final LoginUserDto user;
+}
+
+// 단순 읽기 전용 DTO 일시 레코드 클래스 사용도 좋은 선택
+// 추후 필드 변경 예정이라면 레코드 클래스 사용은 지양하는 것이 좋음
+// 무엇이 맞다보다는 팀의 코드 스타일과 협업 방식에 따라 결정하는 것이 중요함
+// public record LoginResult(String accessToken, String refreshToken, LoginUserDto user) {
+// }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/util/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/util/JwtAuthenticationFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.goormssd.usermanagementbackend.service.CustomUserDetailsService;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -15,59 +17,72 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
     private final CustomUserDetailsService userDetailsService;
 
-    public JwtAuthenticationFilter(JwtUtil jwtUtil, CustomUserDetailsService userDetailsService) {
-        this.jwtUtil = jwtUtil;
-        this.userDetailsService = userDetailsService;
-    }
+    private static final List<String> EXCLUDE_URLS = Arrays.asList(
+            "/api/auth",
+            "/h2-console"
+    );
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return path.startsWith("/api/auth") || path.startsWith("/h2-console");
-        // 이 경로는 필터 적용 제외
+        return EXCLUDE_URLS.stream().anyMatch(path::startsWith);
     }
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-        String token = resolveToken(request);
+        log.debug("[JwtFilter] Request URI: {}", request.getRequestURI());
 
-        if (token != null && jwtUtil.validateToken(token)) {
+        resolveToken(request)
+                .filter(jwtUtil::validateToken)
+                .ifPresent(token -> authenticateToken(token, request));
+
+        filterChain.doFilter(request, response);
+    }
+
+    private Optional<String> resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return Optional.of(bearer.substring(7));
+        }
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return Optional.of(cookie.getValue());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+
+    private void authenticateToken(String token, HttpServletRequest request) {
+        try {
             String email = jwtUtil.extractEmail(token);
             UserDetails userDetails = userDetailsService.loadUserByUsername(email);
             UsernamePasswordAuthenticationToken authToken =
                     new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
             authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authToken);
+            log.info("[JwtFilter] Authentication successful for user: {}", email);
+        } catch (Exception ex) {
+            log.warn("[JwtFilter] Token authentication failed: {}", ex.getMessage());
+            SecurityContextHolder.clearContext();
         }
-
-        filterChain.doFilter(request, response);
-    }
-
-    private String resolveToken(HttpServletRequest request) {
-
-        String bearer = request.getHeader("Authorization");
-
-        if (bearer != null && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
-        }
-
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
-                if ("refreshToken".equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-
-        return null;
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/util/JwtUtil.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/util/JwtUtil.java
@@ -1,10 +1,9 @@
 package org.example.goormssd.usermanagementbackend.util;
 
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +11,7 @@ import javax.crypto.SecretKey;
 import java.util.Base64;
 import java.util.Date;
 
+@Slf4j
 @Component
 public class JwtUtil {
 
@@ -20,6 +20,9 @@ public class JwtUtil {
 
     @Value("${jwt.access-token-expiration-ms:3600000}") // 기본 1시간
     private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration-ms:604800000}") // 기본 7일
+    private long refreshTokenExpiration;
 
     private SecretKey secretKey;
 
@@ -30,33 +33,29 @@ public class JwtUtil {
         this.secretKey = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    // AccessToken 생성
-    public String generateAccessToken(String email) {
+    // 토큰 생성 (사용자 이메일, 만료 시간, 토큰 타입)
+    public String generateToken(String email, long expirationMs) {
         return Jwts.builder()
                 .setSubject(email)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public String generateAccessToken(String email) {
+        return generateToken(email, accessTokenExpiration);
     }
 
     // RefreshToken 생성 (7일)
     public String generateRefreshToken(String email) {
-        long expiration = 1000L * 60 * 60 * 24 * 7; // 7일
-        return Jwts.builder()
-                .setSubject(email)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + expiration))
-                .signWith(secretKey, SignatureAlgorithm.HS256)
-                .compact();
+        return generateToken(email, refreshTokenExpiration);
     }
+
 
     // 이메일 추출
     public String extractEmail(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
+        return parseClaims(token)
                 .getBody()
                 .getSubject();
     }
@@ -64,15 +63,20 @@ public class JwtUtil {
     // 토큰 유효성 검사
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
-                    .build()
-                    .parseClaimsJws(token);
+            parseClaims(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
-            System.out.println("[JWT 검증 실패] 원인: " + e.getMessage());  // 로그 추가
+            log.warn("[JWT 검증 실패] 원인: {}", e.getMessage());
             return false;
         }
+    }
+
+    private Jws<Claims> parseClaims(String token) {
+        String rawToken = token.startsWith("Bearer ") ? token.substring(7) : token;
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(rawToken);
     }
 }
 

--- a/src/main/java/org/example/goormssd/usermanagementbackend/util/TokenProvider.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/util/TokenProvider.java
@@ -1,30 +1,39 @@
-package org.example.goormssd.usermanagementbackend.util;
+//package org.example.goormssd.usermanagementbackend.util;
+//
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//public class TokenProvider {
+//
+//    private final JwtUtil jwtUtil;
+//
+//    public TokenProvider(JwtUtil jwtUtil) {
+//        this.jwtUtil = jwtUtil;
+//    }
+//
+//    // AccessToken은 일반적인 인증에 사용 (1시간)
+//    public String generateAccessToken(String email) {
+//        return jwtUtil.generateAccessToken(email);
+//    }
+//
+//    // RefreshToken은 장기 세션 유지에 사용 (7일)
+//    public String generateRefreshToken(String email) {
+//        return jwtUtil.generateRefreshToken(email);
+//    }
+//
+//    // 토큰 유효성 검사
+//    public boolean validateToken(String token) {
+//        return jwtUtil.validateToken(token);
+//    }
+//
+//    // 토큰에서 이메일(subject) 추출
+//    public String extractEmail(String token) {
+//        return jwtUtil.extractEmail(token);
+//    }
+//}
 
-import org.springframework.stereotype.Component;
-
-@Component
-public class TokenProvider {
-
-    private final JwtUtil jwtUtil;
-
-    public TokenProvider(JwtUtil jwtUtil) {
-        this.jwtUtil = jwtUtil;
-    }
-
-    public String generateAccessToken(String email) {
-        return jwtUtil.generateToken(email);
-    }
-
-    public String generateRefreshToken(String email) {
-        // Implement refresh token generation logic
-        return jwtUtil.generateToken(email); // Placeholder
-    }
-
-    public boolean validateToken(String token) {
-        return jwtUtil.validateToken(token);
-    }
-
-    public String extractEmail(String token) {
-        return jwtUtil.extractEmail(token);
-    }
-}
+// TokenProvider.java 삭제
+// JwtUtil.java로 통합
+// 기능이 추가되지 않고 단순 중계만 하는 경우로 보여서
+// JwtUtil에서 직접 사용하는 것이 더 간결하고 명확함
+// 향후 기능 확장이 상정되어 있다면 유지하는 것도 고려대상으로 보임


### PR DESCRIPTION
## 🔀 PR 제목
 - [Refactor] 로그인·로그아웃
 - [Feature] 토큰 재발급 
---

## 📌 작업 내용 요약

1. **리팩토링**  
   - `JwtAuthenticationFilter` 책임 분리 및 SLF4J 로깅 적용  
   - `AuthController.logout`에 AccessToken 검증 로직 추가  
   - `SecurityConfig` 필터체인 반환 타입·CSRF·세션 설정 간소화  
   - `JwtUtil` 토큰 생성·파싱 공통화  
   - `Token` 엔티티 soft-delete 설정 및 테이블명 변경  
   - `AuthService`, `CustomUserDetailsService`에서 빌더 패턴·로깅 보강  
   - DTO & Repository 불필요 import 제거 및 주석 보강  
  
2. **토큰 재발급 기능**  
   - `/api/auth/refresh` 엔드포인트 추가  
   - `RefreshTokenDto` 응답 DTO 생성  
   - `AuthController.refreshToken()` 구현  
     - 쿠키에서 RefreshToken 추출  
     - `AuthService.isValidRefreshToken()` 호출 (토큰 유효·이메일 인증·계정 상태 체크)  
     - `JwtUtil.generateAccessToken()`으로 신규 AccessToken 발급  
     - `ApiResponseDto<RefreshTokenDto>` 형식으로 응답  
   - 예외 처리  
     - RefreshToken 누락 → `400 Bad Request`  
     - RefreshToken 무효/만료/인증 미완료 → `401 Unauthorized` 또는 `403 Forbidden`  

---

## ✅ 체크리스트

- [ ] 리팩토링 내역 문서화 및 코드 반영 사항 일치 확인  
- [ ] `/api/auth/token/refresh` 기능 요구사항 구현 완료  
- [ ] AccessToken 검증 및 RefreshToken 유효성·인증 상태 검사 통과  
- [ ] Postman 등으로 수동 테스트 완료  

---

## 🔗 관련 이슈

- Closes #15 
- Closes #35 

- Related to #34 
---

## 📎 기타 참고 사항
- RefreshToken은 재발급하지 않고 AccessToken만 신규 발급합니다.  
