### PR TITLE
Feature/profile

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/MemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/MemberController.java
@@ -5,31 +5,30 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.dto.request.EmailCheckRequestDto;
 import org.example.goormssd.usermanagementbackend.dto.request.SignupRequestDto;
+import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.MyProfileResponseDto;
 import org.example.goormssd.usermanagementbackend.service.MemberService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/signup")
+    @PostMapping("/auth/signup")
     public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDto requestDto) {
         // 회원 저장 및 이메일 인증 처리까지 서비스에서 수행
         memberService.signup(requestDto);
         return ResponseEntity.ok("회원가입이 완료되었습니다. 이메일을 확인해주세요.");
     }
 
-    @PostMapping("/email")
+    @PostMapping("/auth/email")
     public ResponseEntity<Map<String, Object>> checkEmailDuplicate(@RequestBody @Valid EmailCheckRequestDto requestDto) {
         boolean exists = memberService.isEmailDuplicate(requestDto.getEmail());
 
@@ -43,5 +42,19 @@ public class MemberController {
             response.put("message", "사용가능한 이메일입니다.");
             return ResponseEntity.ok(response);
         }
+    }
+
+    @GetMapping("/users/me")
+    public ResponseEntity<ApiResponseDto<MyProfileResponseDto>> getMyProfile() {
+
+        MyProfileResponseDto responseDto = memberService.getMyProfile();
+
+        ApiResponseDto<MyProfileResponseDto> response = new ApiResponseDto<>(
+                200,
+                "User information retrieved successfully.",
+                responseDto
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MyProfileResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MyProfileResponseDto.java
@@ -1,0 +1,14 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MyProfileResponseDto {
+    private Long id;
+    private String username;
+    private String email;
+    private String phoneNumber;
+    private String Password;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/MemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/MemberService.java
@@ -3,7 +3,10 @@ package org.example.goormssd.usermanagementbackend.service;
 import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.example.goormssd.usermanagementbackend.dto.request.SignupRequestDto;
+import org.example.goormssd.usermanagementbackend.dto.response.MyProfileResponseDto;
 import org.example.goormssd.usermanagementbackend.repository.MemberRepository;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -50,5 +53,27 @@ public class MemberService {
 
     public boolean isEmailDuplicate(String email) {
         return memberRepository.existsByEmail(email);
+    }
+
+    public MyProfileResponseDto getMyProfile() {
+        // SecurityContext 에 세팅된 UserDetails 의 username 으로 Member 조회
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String email;
+        if (principal instanceof UserDetails) {
+            email = ((UserDetails) principal).getUsername();
+        } else {
+            email = principal.toString();
+        }
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("등록된 회원이 아닙니다."));
+
+        return new MyProfileResponseDto(
+                member.getId(),
+                member.getUsername(),
+                member.getEmail(),
+                member.getPhoneNumber(),
+                member.getPassword() // 실제로는 비밀번호를 반환하지 않도록 주의
+        );
     }
 }


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 마이 프로필 조회 기능 구현  

---

## 📌 작업 내용 요약

- `MyProfileResponseDto` DTO 클래스 추가  
- 공통 응답 래퍼 `ApiResponseDto<T>` 적용하여 `/api/users/me` 응답 구조 통일  
- `MemberService#getMyProfile()` 메서드 구현 및 SecurityContext 기반 사용자 조회 로직 작성  
- `MemberController#getMyProfile()` 엔드포인트 추가  

---

## ✅ 체크리스트

- [ ] API 명세서에 `GET /api/users/me` 엔드포인트 정의  
- [ ] `MyProfileResponseDto` 및 `ApiResponseDto<T>` 클래스 구현  
- [ ] `MemberService#getMyProfile()` 로직 정상 동작 확인  
- [ ] `MebeberController#getMyProfile()` 정상 응답 확인  
- [ ] SecurityConfig에 권한 설정 반영  
- [ ] 예외 처리(토큰 미제공, DB 미조회) 동작 확인  

---

## 🔗 관련 이슈
- Closes #16 

---

## 📎 기타 참고 사항
- 실제 운영 환경에서는 비밀번호(`password`) 필드를 응답에서 제거해야 한다.  
