### PR TITLE
Feature/list

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -1,0 +1,32 @@
+package org.example.goormssd.usermanagementbackend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.DashboardResponseDto;
+import org.example.goormssd.usermanagementbackend.service.AdminMemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+public class AdminMemberController {
+
+    private final AdminMemberService adminMemberService;
+
+    @GetMapping("/dashboard")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseDto<DashboardResponseDto>> getDashboard(
+            @RequestParam(name = "pageNum",   defaultValue = "1")  int pageNum,
+            @RequestParam(name = "pageLimit", defaultValue = "10") int pageLimit
+    ) {
+        DashboardResponseDto responseDto = adminMemberService.getDashboard(pageNum, pageLimit);
+        ApiResponseDto<DashboardResponseDto> response =
+                ApiResponseDto.of(200, "대시 보드 조회 성공", responseDto);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -3,14 +3,12 @@ package org.example.goormssd.usermanagementbackend.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.DashboardResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.MemberDetailResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.MemberListResponseDto;
 import org.example.goormssd.usermanagementbackend.service.AdminMemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/admin/users")
@@ -73,4 +71,12 @@ public class AdminMemberController {
         );
     }
 
+    @GetMapping("/{email}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseDto<MemberDetailResponseDto>> getMemberDetail(
+            @PathVariable String email
+    ) {
+        MemberDetailResponseDto dto = adminMemberService.getMemberDetailByEmail(email);
+        return ResponseEntity.ok(ApiResponseDto.of(200, "User information retrieved successfully.", dto));
+    }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -3,6 +3,7 @@ package org.example.goormssd.usermanagementbackend.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.DashboardResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.MemberListResponseDto;
 import org.example.goormssd.usermanagementbackend.service.AdminMemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -28,5 +29,19 @@ public class AdminMemberController {
         ApiResponseDto<DashboardResponseDto> response =
                 ApiResponseDto.of(200, "대시 보드 조회 성공", responseDto);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseDto<MemberListResponseDto>> getAllMembers(
+            @RequestParam(name = "pageNum", defaultValue = "1") int pageNum,
+            @RequestParam(name = "pageLimit", defaultValue = "10") int pageLimit,
+            @RequestParam(name = "sortBy", defaultValue = "createdAt") String sortBy,
+            @RequestParam(name = "sortDir", defaultValue = "desc") String sortDir
+    ) {
+        MemberListResponseDto dto = adminMemberService.getAllMembers(pageNum, pageLimit, sortBy, sortDir);
+        return ResponseEntity.ok(
+                ApiResponseDto.of(200, "전체 회원 조회 성공", dto)
+        );
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -58,4 +58,19 @@ public class AdminMemberController {
                 ApiResponseDto.of(200, "탈퇴 회원 조회 성공", dto)
         );
     }
+
+    @GetMapping("/unverified")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseDto<MemberListResponseDto>> getUnverifiedEmailMembers(
+            @RequestParam(name = "pageNum",   defaultValue = "1")         int pageNum,
+            @RequestParam(name = "pageLimit", defaultValue = "10")        int pageLimit,
+            @RequestParam(name = "sortBy",    defaultValue = "createdAt") String sortBy,
+            @RequestParam(name = "sortDir",   defaultValue = "desc")      String sortDir
+    ) {
+        MemberListResponseDto dto = adminMemberService.getUnverifiedEmailMembers(pageNum, pageLimit, sortBy, sortDir);
+        return ResponseEntity.ok(
+                ApiResponseDto.of(200, "이메일 미인증 회원 조회 성공", dto)
+        );
+    }
+
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -44,4 +44,18 @@ public class AdminMemberController {
                 ApiResponseDto.of(200, "전체 회원 조회 성공", dto)
         );
     }
+
+    @GetMapping("/deleted")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseDto<MemberListResponseDto>> getDeletedMembers(
+            @RequestParam(name = "pageNum",   defaultValue = "1")         int pageNum,
+            @RequestParam(name = "pageLimit", defaultValue = "10")        int pageLimit,
+            @RequestParam(name = "sortBy",    defaultValue = "createdAt") String sortBy,
+            @RequestParam(name = "sortDir",   defaultValue = "desc")      String sortDir
+    ) {
+        MemberListResponseDto dto = adminMemberService.getDeletedMembers(pageNum, pageLimit, sortBy, sortDir);
+        return ResponseEntity.ok(
+                ApiResponseDto.of(200, "탈퇴 회원 조회 성공", dto)
+        );
+    }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/ApiResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/ApiResponseDto.java
@@ -13,4 +13,8 @@ public class ApiResponseDto<T> {
     private int status;
     private String message;
     private T data;
+
+    public static <T> ApiResponseDto<T> of(int status, String message, T data) {
+        return new ApiResponseDto<>(status, message, data);
+    }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/DashboardResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/DashboardResponseDto.java
@@ -1,0 +1,18 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DashboardResponseDto {
+    private long sumUser;
+    private long deletedUser;
+    private List<MemberResponseDto> users;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/DashboardResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/DashboardResponseDto.java
@@ -15,4 +15,9 @@ public class DashboardResponseDto {
     private long sumUser;
     private long deletedUser;
     private List<MemberResponseDto> users;
+
+    private int currentPage;
+    private int pageLimit;
+    private int totalPages;
+    private long totalElements;
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberDetailResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberDetailResponseDto.java
@@ -1,0 +1,18 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberDetailResponseDto {
+    private Long id;
+    private String name;
+    private String email;
+    private String phoneNumber;
+    private String password;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberListResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberListResponseDto.java
@@ -1,0 +1,20 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberListResponseDto {
+    private List<MemberResponseDto> users;
+    private int currentPage;
+    private int pageLimit;
+    private int totalPages;
+    private long totalElements;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberResponseDto.java
@@ -1,0 +1,23 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberResponseDto {
+    private Long id;
+    private String username;
+    private String email;
+    private String phoneNumber;
+    private String role;          // USER or ADMIN
+    private String status;        // ACTIVE or DELETED
+    private boolean emailVerified;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Integer> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -12,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Integer> {
 
     boolean existsByEmail(String email);
 
+    long countByStatus(Member.Status status);
+
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package org.example.goormssd.usermanagementbackend.repository;
 
 import org.example.goormssd.usermanagementbackend.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +15,7 @@ public interface MemberRepository extends JpaRepository<Member, Integer> {
     boolean existsByEmail(String email);
 
     long countByStatus(Member.Status status);
+
+    Page<Member> findAllByStatus(Member.Status status, Pageable pageable);
 
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -18,4 +18,6 @@ public interface MemberRepository extends JpaRepository<Member, Integer> {
 
     Page<Member> findAllByStatus(Member.Status status, Pageable pageable);
 
+    Page<Member> findAllByEmailVerifiedFalse(Pageable pageable);
+
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -1,0 +1,44 @@
+package org.example.goormssd.usermanagementbackend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.goormssd.usermanagementbackend.domain.Member;
+import org.example.goormssd.usermanagementbackend.dto.response.DashboardResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.MemberResponseDto;
+import org.example.goormssd.usermanagementbackend.repository.MemberRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberService {
+
+    private final MemberRepository memberRepository;
+
+    public DashboardResponseDto getDashboard(int pageNum, int pageLimit) {
+        Pageable pageable = PageRequest.of(pageNum - 1, pageLimit, Sort.by("createdAt").descending());
+
+        List<MemberResponseDto> users = memberRepository.findAll(pageable)
+                .stream()
+                .map(member -> new MemberResponseDto(
+                        member.getId(),
+                        member.getUsername(),
+                        member.getEmail(),
+                        member.getPhoneNumber(),
+                        member.getRole().name(),
+                        member.getStatus().name().toLowerCase(),
+                        member.isEmailVerified(),
+                        member.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+
+        long sumUser     = memberRepository.count();
+        long deletedUser = memberRepository.countByStatus(Member.Status.DELETED);
+
+        return new DashboardResponseDto(sumUser, deletedUser, users);
+    }
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -5,6 +5,7 @@ import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.example.goormssd.usermanagementbackend.dto.response.DashboardResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.MemberResponseDto;
 import org.example.goormssd.usermanagementbackend.repository.MemberRepository;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,6 +23,8 @@ public class AdminMemberService {
     public DashboardResponseDto getDashboard(int pageNum, int pageLimit) {
         Pageable pageable = PageRequest.of(pageNum - 1, pageLimit, Sort.by("createdAt").descending());
 
+        Page<Member> page = memberRepository.findAll(pageable);
+
         List<MemberResponseDto> users = memberRepository.findAll(pageable)
                 .stream()
                 .map(member -> new MemberResponseDto(
@@ -30,7 +33,7 @@ public class AdminMemberService {
                         member.getEmail(),
                         member.getPhoneNumber(),
                         member.getRole().name(),
-                        member.getStatus().name().toLowerCase(),
+                        member.getStatus().name(),
                         member.isEmailVerified(),
                         member.getCreatedAt()
                 ))
@@ -39,6 +42,14 @@ public class AdminMemberService {
         long sumUser     = memberRepository.count();
         long deletedUser = memberRepository.countByStatus(Member.Status.DELETED);
 
-        return new DashboardResponseDto(sumUser, deletedUser, users);
+        return new DashboardResponseDto(
+                sumUser,
+                deletedUser,
+                users,
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -108,4 +108,32 @@ public class AdminMemberService {
                 page.getTotalElements()
         );
     }
+
+    public MemberListResponseDto getUnverifiedEmailMembers(int pageNum, int pageLimit, String sortBy, String sortDir) {
+        Sort.Direction direction = Sort.Direction.fromString(sortDir);
+        Pageable pageable = PageRequest.of(pageNum - 1, pageLimit, Sort.by(direction, sortBy));
+
+        Page<Member> page = memberRepository.findAllByEmailVerifiedFalse(pageable);
+
+        List<MemberResponseDto> users = page.getContent().stream()
+                .map(member -> new MemberResponseDto(
+                        member.getId(),
+                        member.getUsername(),
+                        member.getEmail(),
+                        member.getPhoneNumber(),
+                        member.getRole().name(),
+                        member.getStatus().name().toLowerCase(),
+                        member.isEmailVerified(),
+                        member.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+
+        return new MemberListResponseDto(
+                users,
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
+    }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -3,6 +3,7 @@ package org.example.goormssd.usermanagementbackend.service;
 import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.example.goormssd.usermanagementbackend.dto.response.DashboardResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.MemberDetailResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.MemberListResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.MemberResponseDto;
 import org.example.goormssd.usermanagementbackend.repository.MemberRepository;
@@ -134,6 +135,18 @@ public class AdminMemberService {
                 page.getSize(),
                 page.getTotalPages(),
                 page.getTotalElements()
+        );
+    }
+
+    public MemberDetailResponseDto getMemberDetailByEmail(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 회원이 존재하지 않습니다. email=" + email));
+        return new MemberDetailResponseDto(
+                member.getId(),
+                member.getUsername(),
+                member.getEmail(),
+                member.getPhoneNumber(),
+                member.getPassword()
         );
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -80,4 +80,32 @@ public class AdminMemberService {
                 page.getTotalElements()
         );
     }
+
+    public MemberListResponseDto getDeletedMembers(int pageNum, int pageLimit, String sortBy, String sortDir) {
+        Sort.Direction direction = Sort.Direction.fromString(sortDir);
+        Pageable pageable = PageRequest.of(pageNum - 1, pageLimit, Sort.by(direction, sortBy));
+
+        Page<Member> page = memberRepository.findAllByStatus(Member.Status.DELETED, pageable);
+
+        List<MemberResponseDto> users = page.getContent().stream()
+                .map(member -> new MemberResponseDto(
+                        member.getId(),
+                        member.getUsername(),
+                        member.getEmail(),
+                        member.getPhoneNumber(),
+                        member.getRole().name(),
+                        member.getStatus().name().toLowerCase(),
+                        member.isEmailVerified(),
+                        member.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+
+        return new MemberListResponseDto(
+                users,
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
+    }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -3,6 +3,7 @@ package org.example.goormssd.usermanagementbackend.service;
 import lombok.RequiredArgsConstructor;
 import org.example.goormssd.usermanagementbackend.domain.Member;
 import org.example.goormssd.usermanagementbackend.dto.response.DashboardResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.MemberListResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.MemberResponseDto;
 import org.example.goormssd.usermanagementbackend.repository.MemberRepository;
 import org.springframework.data.domain.Page;
@@ -33,7 +34,7 @@ public class AdminMemberService {
                         member.getEmail(),
                         member.getPhoneNumber(),
                         member.getRole().name(),
-                        member.getStatus().name(),
+                        member.getStatus().name().toLowerCase(),
                         member.isEmailVerified(),
                         member.getCreatedAt()
                 ))
@@ -45,6 +46,33 @@ public class AdminMemberService {
         return new DashboardResponseDto(
                 sumUser,
                 deletedUser,
+                users,
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
+    }
+
+    public MemberListResponseDto getAllMembers(int pageNum, int pageLimit, String sortBy, String sortDir) {
+        Sort.Direction direction = Sort.Direction.fromString(sortDir);
+        Pageable pageable = PageRequest.of(pageNum - 1, pageLimit, Sort.by(direction, sortBy));
+        Page<Member> page = memberRepository.findAll(pageable);
+
+        List<MemberResponseDto> users = page.getContent().stream()
+                .map(member -> new MemberResponseDto(
+                        member.getId(),
+                        member.getUsername(),
+                        member.getEmail(),
+                        member.getPhoneNumber(),
+                        member.getRole().name(),
+                        member.getStatus().name().toLowerCase(),
+                        member.isEmailVerified(),
+                        member.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+
+        return new MemberListResponseDto(
                 users,
                 page.getNumber() + 1,
                 page.getSize(),


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 관리자 회원 관련 API 구현 (대시보드, 전체 조회, 미인증 조회, 탈퇴 조회, 상세 조회)
- [Refactor] AdminMemberService 및 Controller 구조 통합 정리

---

## 📌 작업 내용 요약
 - 대시보드 조회: /api/admin/users/dashboard
   - 전체 회원 수, 탈퇴 회원 수, 페이징된 회원 리스트, 페이징 메타 정보 포함
 - 전체 회원 조회: /api/admin/users
   - 페이징·정렬 옵션(pageNum, pageLimit, sortBy, sortDir) 적용
 - 이메일 미인증 회원 조회: /api/admin/users/unverified
   - emailVerified=false 회원만 페이징·정렬 조회
 - 탈퇴 회원 조회: /api/admin/users/deleted
   - status=DELETED 회원만 페이징·정렬 조회
 - 회원 상세 정보 조회: /api/admin/users/{email}
   - 이메일 기준으로 단일 회원 상세 필드 조회
   - 
 - 각 기능별 Service 메서드, Repository 쿼리 메서드, DTO 클래스, Controller 엔드포인트를 구현하고, 공통 응답 래퍼(ApiResponseDto)와 권한 검증(hasRole('ADMIN'))을 적용
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] DashboardResponseDto, MemberListResponseDto, MemberDetailResponseDto DTO 작성
- [ ] MemberRepository에 countByStatus, findAllByStatus, findAllByEmailVerifiedFalse, findByEmail 메서드 추가
- [ ] AdminMemberService에 다음 메서드 구현
  - getDashboard(int, int)
  - getAllMembers(int, int, String, String)
  - getUnverifiedMembers(int, int, String, String)
  - getDeletedMembers(int, int, String, String)
  - getMemberDetailByEmail(String)
- [ ] AdminMemberController에 각 엔드포인트 맵핑
- [ ] 공통 응답 래퍼(ApiResponseDto.of) 활용
- [ ] @PreAuthorize("hasRole('ADMIN')") 권한 검사 적용

---

## 🔗 관련 이슈

- Closes #17 
- Closes #40 
- Closes #41 
- Closes #42 
- Closes #43 

---

## 📎 기타 참고 사항
- 프론트 연동 예시:
 // 대시보드
 axios.get('/api/admin/users/dashboard', { params: { pageNum:1, pageLimit:10 } });
// 전체 회원
 axios.get('/api/admin/users', { params: { pageNum:1, pageLimit:20, sortBy:'createdAt', sortDir:'desc' } });
// 미인증 회원
 axios.get('/api/admin/users/unverified', { params: {...} });
// 탈퇴 회원
 axios.get('/api/admin/users/deleted', { params: {...} });
// 상세 조회
 axios.get(`/api/admin/users/${email}`);

- 민감 정보(password) 노출 여부 보안 검토 필요.