### PR TITLE
feat(search): 이메일 및 사용자명 필터를 활용한 회원 검색 기능 추가

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -1,10 +1,7 @@
 package org.example.goormssd.usermanagementbackend.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
-import org.example.goormssd.usermanagementbackend.dto.response.DashboardResponseDto;
-import org.example.goormssd.usermanagementbackend.dto.response.MemberDetailResponseDto;
-import org.example.goormssd.usermanagementbackend.dto.response.MemberListResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.*;
 import org.example.goormssd.usermanagementbackend.service.AdminMemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -78,5 +75,28 @@ public class AdminMemberController {
     ) {
         MemberDetailResponseDto dto = adminMemberService.getMemberDetailByEmail(email);
         return ResponseEntity.ok(ApiResponseDto.of(200, "User information retrieved successfully.", dto));
+    }
+
+    @GetMapping("/search")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseDto<MemberListResponseDto>> searchMembers(
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) String username,
+            @RequestParam(name = "pageNum", defaultValue = "1") int pageNum,
+            @RequestParam(name = "pageLimit", defaultValue = "10") int pageLimit,
+            @RequestParam(name = "sortBy", defaultValue = "createdAt") String sortBy,
+            @RequestParam(name = "sortDir", defaultValue = "desc") String sortDir
+    ) {
+        // email과 username 동시 사용 제한
+        if (email != null && username != null) {
+            return ResponseEntity.badRequest().body(
+                    ApiResponseDto.of(400, "email과 username은 동시에 검색할 수 없습니다.", null)
+            );
+        }
+
+        MemberListResponseDto dto = adminMemberService.searchMembers(email, username, pageNum, pageLimit, sortBy, sortDir);
+        return ResponseEntity.ok(
+                ApiResponseDto.of(200, "회원 검색 성공", dto)
+        );
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -20,4 +20,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Page<Member> findAllByEmailVerifiedFalse(Pageable pageable);
 
+    Page<Member> findByEmailContainingIgnoreCase(String email, Pageable pageable);
+
+    Page<Member> findByUsernameContainingIgnoreCase(String username, Pageable pageable);
+
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -149,4 +149,40 @@ public class AdminMemberService {
                 member.getPassword()
         );
     }
+
+    public MemberListResponseDto searchMembers(String email, String username, int pageNum, int pageLimit, String sortBy, String sortDir) {
+        Sort.Direction direction = Sort.Direction.fromString(sortDir);
+        Pageable pageable = PageRequest.of(pageNum - 1, pageLimit, Sort.by(direction, sortBy));
+
+        Page<Member> page;
+
+        if (email != null && !email.isBlank()) {
+            page = memberRepository.findByEmailContainingIgnoreCase(email, pageable);
+        } else if (username != null && !username.isBlank()) {
+            page = memberRepository.findByUsernameContainingIgnoreCase(username, pageable);
+        } else {
+            page = memberRepository.findAll(pageable);
+        }
+
+        List<MemberResponseDto> users = page.getContent().stream()
+                .map(member -> new MemberResponseDto(
+                        member.getId(),
+                        member.getUsername(),
+                        member.getEmail(),
+                        member.getPhoneNumber(),
+                        member.getRole().name(),
+                        member.getStatus().name().toLowerCase(),
+                        member.isEmailVerified(),
+                        member.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+
+        return new MemberListResponseDto(
+                users,
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements()
+        );
+    }
 }


### PR DESCRIPTION
## 🔀 PR 제목

[Feature] 회원 검색 기능 구현 (이메일/이름 기반 필터 + 페이지네이션)

---

## 📌 작업 내용 요약

- 관리자용 회원 검색 API(/api/admin/users/search) 구현
- 이메일 또는 사용자명으로 검색 가능 (부분 일치)
- pageNum, pageLimit, sortBy, sortDir 적용'
- 공통 응답 포맷(ApiResponseDto) 및 목록 DTO(MemberListResponseDto) 사용

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #18 

---

## 📎 기타 참고 사항

- 기존 /api/admin/users 전체 조회 API 형식과 동일한 DTO/응답 포맷 사용
- 추후 역할/상태 필터 조건 추가 가능
