### PR TITLE
feat(find_email + new_password): find_email + new_password 생성

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AuthController.java
@@ -5,8 +5,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.goormssd.usermanagementbackend.dto.request.FindEmailRequestDto;
+import org.example.goormssd.usermanagementbackend.dto.request.FindPasswordRequestDto;
 import org.example.goormssd.usermanagementbackend.dto.request.LoginRequestDto;
 import org.example.goormssd.usermanagementbackend.dto.response.ApiResponseDto;
+import org.example.goormssd.usermanagementbackend.dto.response.FindEmailResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.LoginResponseDto;
 import org.example.goormssd.usermanagementbackend.dto.response.RefreshTokenDto;
 import org.example.goormssd.usermanagementbackend.service.AuthService;
@@ -175,5 +178,17 @@ public class AuthController {
 
         return ResponseEntity.ok(apiResponse);
     }
+    @PostMapping("/auth/find/email")
+    public ResponseEntity<ApiResponseDto<FindEmailResponseDto>> findEmail(@RequestBody FindEmailRequestDto request) {
+        String email = authService.findEmailByUsernameAndPhone(request);
+        return ResponseEntity.ok(new ApiResponseDto<>(200, "Email (ID) retrieved successfully.", new FindEmailResponseDto(email)));
+    }
+
+    @PostMapping("/auth/find/password")
+    public ResponseEntity<ApiResponseDto<Void>> resetPassword(@RequestBody FindPasswordRequestDto request) {
+        authService.resetPasswordAndSendEmail(request);
+        return ResponseEntity.ok(new ApiResponseDto<>(200, "Temporary password has been sent via email.", null));
+    }
+
 
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/FindEmailRequestDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/FindEmailRequestDto.java
@@ -1,0 +1,10 @@
+package org.example.goormssd.usermanagementbackend.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class FindEmailRequestDto {
+    private String username;
+    private String phoneNumber;
+    private String code; // 인증번호 입력
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/FindPasswordRequestDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/FindPasswordRequestDto.java
@@ -1,0 +1,9 @@
+package org.example.goormssd.usermanagementbackend.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class FindPasswordRequestDto {
+    private String username;
+    private String email;
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/FindEmailResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/FindEmailResponseDto.java
@@ -1,0 +1,10 @@
+package org.example.goormssd.usermanagementbackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindEmailResponseDto {
+    private String email;
+}


### PR DESCRIPTION
이메일 찾기와 임시 비밀번호 생성 기능
휴대폰 인증은 일단 확인하지 않고 진행

## 🔀 PR 제목
- [Feature] 이메일 찾기와 임시 비밀번호 발급 기능 추가 

---

## 📌 작업 내용 요약

- 이메일 찾기 기능 추가
- 이메일 찾기 시 휴대폰 인증은 일단 확인하지 않고 진행
- 임시 비밀번호 발급 기능 추가

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 사용자의 이름과 전화번호 + 인증번호(인증번호는 일단 아무 값이나 넣고 하시면 됩니다. 확인하지 않습니다) 추가 후 이메일 찾기를 진행했을 때 제대로 돌아가나요?
- [ ] 사용자의 이름과 이메일을 넣었을 때 임시 비밀번호 발급이 되나요?


---

## 🔗 관련 이슈
`Closes #` 또는 `Related to #이슈번호` 형태로 작성

예시:
- Closes #10 
- Related to #10 
---

## 📎 기타 참고 사항
- 현재 같은 이름과 전화번호로 입력화면 회원가입이 두번되지만 맨 처음에 진행한 이메일만 DTO를 통해서 확인할 수 있기 떄문에 주의 바람 
- 해당 사안은 리팩토링 과정에서 수정할 예정
