### PR TITLE
feat(cors): CORS 설정을 구현하고 application 설정 파일을 업데이트함

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/config/SecurityConfig.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/config/SecurityConfig.java
@@ -15,6 +15,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 import static org.springframework.http.HttpMethod.*;
 
@@ -94,5 +99,19 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:5173")); // Vite + 서버 주소
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    database-platform: org.hibernate.dialect.MySQLDialect  # ✅ 권장 dialect로 수정 (MySQL8Dialect은 deprecated)
+    database-platform: org.hibernate.dialect.MySQLDialect
 
   mail:
     host: smtp.gmail.com
@@ -33,6 +33,12 @@ coolsms:
     key: ${COOLSMS_API_KEY}
     secret: ${COOLSMS_API_SECRET}
     number: ${COOLSMS_API_NUMBER}
+
+springdoc:
+  swagger-ui:
+    disable-swagger-default-url: true
+    csrf:
+      enabled: false
 
 server:
   port: 8080


### PR DESCRIPTION
## 🔀 PR 제목

[Feature] CORS 설정 구현 및 application 설정 파일 수정

---

## 📌 작업 내용 요약

- http://localhost:5173 도메인에서 API 요청 가능하도록 허용
- JWT 인증 및 쿠키 기반 요청을 위해 allowCredentials(true) 설정 적용
- Swagger UI 및 Postman에서도 self-signed 인증서를 통한 요청 가능하도록 application.yml 업데이트 (csrf.disable, swagger-default-url 비활성화 포함)
- application.yml에 환경 변수 기반 구성 적용 (jwt, mail, datasource, coolsms 등)

---

## ✅ 체크리스트

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #77 

---

## 📎 기타 참고 사항

- Swagger UI 접근 시 self-signed 인증서 경고가 나타날 수 있음 → 브라우저에서 수동 예외 처리 필요
- Postman에서는 Settings > General > SSL certificate verification을 Off로 설정해야 테스트 가능
- 프론트엔드에서 withCredentials: true를 Axios 설정에 추가 필요
