### PR TITLE
Fix/list

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -35,10 +35,19 @@ public class AdminMemberController {
     public ResponseEntity<ApiResponseDto<DashboardResponseDto>> getDashboard(
             @Parameter(description = "페이지 번호", example = "1")
             @RequestParam(name = "pageNum",   defaultValue = "1")  int pageNum,
+
             @Parameter(description = "한 페이지당 회원 수", example = "10")
-            @RequestParam(name = "pageLimit", defaultValue = "10") int pageLimit
+            @RequestParam(name = "pageLimit", defaultValue = "10") int pageLimit,
+
+            @Parameter(description = "이메일 인증 여부 (true/false)", example = "true")
+            @RequestParam(name = "emailVerified", required = false) Boolean emailVerified,
+
+            @Parameter(description = "회원 상태 (active/deleted)", example = "active")
+            @RequestParam(name = "status", required = false) String status
     ) {
-        DashboardResponseDto responseDto = adminMemberService.getDashboard(pageNum, pageLimit);
+        DashboardResponseDto responseDto = adminMemberService.getDashboard(
+                pageNum, pageLimit, emailVerified, status);
+
         ApiResponseDto<DashboardResponseDto> response =
                 ApiResponseDto.of(200, "대시 보드 조회 성공", responseDto);
         return ResponseEntity.ok(response);

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -24,4 +24,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Page<Member> findByUsernameContainingIgnoreCase(String username, Pageable pageable);
 
+    Page<Member> findByEmailVerifiedAndStatus(Boolean emailVerified, Member.Status statusEnum, Pageable pageable);
+
+    Page<Member> findByEmailVerified(Boolean emailVerified, Pageable pageable);
+
+    Page<Member> findByStatus(Member.Status statusEnum, Pageable pageable);
 }


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 관리자 대시보드 필터 기능 추가
- 
---

## 📌 작업 내용 요약

- 대시보드 조회 API에 emailVerified, status 필터 파라미터 추가
- Service 계층에서 조건별 분기 처리 로직 추가
- 전체 회원 수 및 탈퇴 회원 수 집계 로직 유지
- QueryDSL 미사용, JPA 조건 메서드로 구현 (추후 리팩토링 예정)

---

## ✅ 체크리스트


- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #85 
- Related to #86 
---

## 📎 기타 참고 사항

- 프론트에서 필터 옵션: 이메일 인증 여부(true/false), 회원 상태(active/deleted) 전달 가능
- 향후 QueryDSL로 조건 쿼리 리팩토링 예정
- 필터 조건 조합 시 잘못된 status 값(blocked 등)에 대한 예외처리 포함됨
