### PR TITLE
Fix/search

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -166,7 +166,13 @@ public class AdminMemberController {
             @RequestParam(name = "sortBy", defaultValue = "createdAt") String sortBy,
 
             @Parameter(description = "정렬 방향 (asc 또는 desc)", example = "desc")
-            @RequestParam(name = "sortDir", defaultValue = "desc") String sortDir
+            @RequestParam(name = "sortDir", defaultValue = "desc") String sortDir,
+
+            @Parameter(description = "이메일 인증 여부 (true/false)", example = "true")
+            @RequestParam(name = "emailVerified", required = false) Boolean emailVerified,
+
+            @Parameter(description = "회원 상태 (active/deleted)", example = "active")
+            @RequestParam(name = "status", required = false) String status
     ) {
         // email과 username 동시 사용 제한
         if (email != null && username != null) {
@@ -175,7 +181,9 @@ public class AdminMemberController {
             );
         }
 
-        MemberListResponseDto dto = adminMemberService.searchMembers(email, username, pageNum, pageLimit, sortBy, sortDir);
+        MemberListResponseDto dto = adminMemberService.searchMembers(
+                email, username, pageNum, pageLimit, sortBy, sortDir, emailVerified, status
+        );
         return ResponseEntity.ok(
                 ApiResponseDto.of(200, "회원 검색 성공", dto)
         );

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberListResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberListResponseDto.java
@@ -1,12 +1,10 @@
 package org.example.goormssd.usermanagementbackend.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
+@Builder
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberResponseDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/response/MemberResponseDto.java
@@ -1,12 +1,10 @@
 package org.example.goormssd.usermanagementbackend.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
+@Builder
 @Getter
 @Setter
 @AllArgsConstructor

--- a/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/repository/MemberRepository.java
@@ -24,4 +24,21 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Page<Member> findByUsernameContainingIgnoreCase(String username, Pageable pageable);
 
+    Page<Member> findByEmailContainingIgnoreCaseAndEmailVerifiedAndStatus(String email, Boolean emailVerified, Member.Status statusEnum, Pageable pageable);
+
+    Page<Member> findByEmailContainingIgnoreCaseAndEmailVerified(String email, Boolean emailVerified, Pageable pageable);
+
+    Page<Member> findByEmailContainingIgnoreCaseAndStatus(String email, Member.Status statusEnum, Pageable pageable);
+
+    Page<Member> findByUsernameContainingIgnoreCaseAndEmailVerifiedAndStatus(String username, Boolean emailVerified, Member.Status statusEnum, Pageable pageable);
+
+    Page<Member> findByUsernameContainingIgnoreCaseAndEmailVerified(String username, Boolean emailVerified, Pageable pageable);
+
+    Page<Member> findByUsernameContainingIgnoreCaseAndStatus(String username, Member.Status statusEnum, Pageable pageable);
+
+    Page<Member> findByEmailVerifiedAndStatus(Boolean emailVerified, Member.Status statusEnum, Pageable pageable);
+
+    Page<Member> findByEmailVerified(Boolean emailVerified, Pageable pageable);
+
+    Page<Member> findByStatus(Member.Status statusEnum, Pageable pageable);
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -150,18 +150,56 @@ public class AdminMemberService {
         );
     }
 
-    public MemberListResponseDto searchMembers(String email, String username, int pageNum, int pageLimit, String sortBy, String sortDir) {
+    public MemberListResponseDto searchMembers(
+            String email, String username,
+            int pageNum, int pageLimit,
+            String sortBy, String sortDir,
+            Boolean emailVerified, String status
+    ) {
         Sort.Direction direction = Sort.Direction.fromString(sortDir);
         Pageable pageable = PageRequest.of(pageNum - 1, pageLimit, Sort.by(direction, sortBy));
 
         Page<Member> page;
 
+        Member.Status statusEnum = null;
+        if (status != null && !status.isBlank()) {
+            try {
+                statusEnum = Member.Status.valueOf(status.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("잘못된 status 값입니다. (active 또는 deleted)");
+            }
+        }
+
         if (email != null && !email.isBlank()) {
-            page = memberRepository.findByEmailContainingIgnoreCase(email, pageable);
+            if (emailVerified != null && statusEnum != null) {
+                page = memberRepository.findByEmailContainingIgnoreCaseAndEmailVerifiedAndStatus(email, emailVerified, statusEnum, pageable);
+            } else if (emailVerified != null) {
+                page = memberRepository.findByEmailContainingIgnoreCaseAndEmailVerified(email, emailVerified, pageable);
+            } else if (statusEnum != null) {
+                page = memberRepository.findByEmailContainingIgnoreCaseAndStatus(email, statusEnum, pageable);
+            } else {
+                page = memberRepository.findByEmailContainingIgnoreCase(email, pageable);
+            }
         } else if (username != null && !username.isBlank()) {
-            page = memberRepository.findByUsernameContainingIgnoreCase(username, pageable);
+            if (emailVerified != null && statusEnum != null) {
+                page = memberRepository.findByUsernameContainingIgnoreCaseAndEmailVerifiedAndStatus(username, emailVerified, statusEnum, pageable);
+            } else if (emailVerified != null) {
+                page = memberRepository.findByUsernameContainingIgnoreCaseAndEmailVerified(username, emailVerified, pageable);
+            } else if (statusEnum != null) {
+                page = memberRepository.findByUsernameContainingIgnoreCaseAndStatus(username, statusEnum, pageable);
+            } else {
+                page = memberRepository.findByUsernameContainingIgnoreCase(username, pageable);
+            }
         } else {
-            page = memberRepository.findAll(pageable);
+            if (emailVerified != null && statusEnum != null) {
+                page = memberRepository.findByEmailVerifiedAndStatus(emailVerified, statusEnum, pageable);
+            } else if (emailVerified != null) {
+                page = memberRepository.findByEmailVerified(emailVerified, pageable);
+            } else if (statusEnum != null) {
+                page = memberRepository.findByStatus(statusEnum, pageable);
+            } else {
+                page = memberRepository.findAll(pageable);
+            }
         }
 
         List<MemberResponseDto> users = page.getContent().stream()


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 회원 검색 API 필터 기능 추가

---

## 📌 작업 내용 요약

- 검색 API(/api/admin/search)에 emailVerified, status 파라미터 추가
- 이메일 또는 이름 중 하나로만 검색 가능 (동시 사용 시 400 에러 처리)
- 이메일 인증 여부 및 회원 상태 조합에 따른 검색 분기 처리
- Repository에 조건 조합에 따른 JPA 메서드 10개 이상 정의
- 정렬 기준(sortBy)과 방향(sortDir) 적용 유지

---

## ✅ 체크리스트

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #86 
- Related to #85 

---

## 📎 기타 참고 사항

- 잘못된 status 값(ex: blocked) 요청 시 예외 처리 (IllegalArgumentException)
- email과 username을 동시에 요청할 경우 BadRequest 처리
- QueryDSL 없이 JPA 조건 메서드만으로 분기 처리 (향후 리팩토링 예정)
- 프론트 요청 예시:
   - /api/admin/search?email=test@example.com&emailVerified=true&status=active
   - /api/admin/search?username=홍길동&status=deleted
