### PR TITLE
feat(status): 관리자가 회원 상태를 변경할 수 있는 엔드포인트 추가

### DIFF
--- a/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/controller/AdminMemberController.java
@@ -2,9 +2,12 @@ package org.example.goormssd.usermanagementbackend.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.example.goormssd.usermanagementbackend.dto.request.UpdateStatusRequestDto;
 import org.example.goormssd.usermanagementbackend.dto.response.*;
 import org.example.goormssd.usermanagementbackend.service.AdminMemberService;
 import org.springframework.http.ResponseEntity;
@@ -196,5 +199,26 @@ public class AdminMemberController {
         return ResponseEntity.ok(
                 ApiResponseDto.of(200, "회원 검색 성공", dto)
         );
+    }
+
+    @PatchMapping("/status/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(
+            summary = "회원 상태 변경 (ADMIN)",
+            description = "관리자가 회원의 상태를 변경합니다. 'active' 또는 'deleted' 중 하나를 입력해야 합니다."
+    )
+    public ResponseEntity<ApiResponseDto<Void>> updateUserStatus(
+            @Parameter(description = "회원 ID", example = "1")
+            @PathVariable Long id,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 회원 상태 ('active' 또는 'deleted')",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = UpdateStatusRequestDto.class))
+            )
+            @RequestBody UpdateStatusRequestDto requestDto) {
+
+        adminMemberService.updateStatus(id, requestDto.getStatus());
+        return ResponseEntity.ok(ApiResponseDto.of(200, "User status has been updated.", null));
     }
 }

--- a/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/UpdateStatusRequestDto.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/dto/request/UpdateStatusRequestDto.java
@@ -1,0 +1,22 @@
+package org.example.goormssd.usermanagementbackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "회원 상태 변경 요청 DTO")
+public class UpdateStatusRequestDto {
+
+    @Schema(
+            description = "회원 상태 값 (active 또는 deleted)",
+            example = "deleted",
+            allowableValues = {"active", "deleted"}
+    )
+    private String status; // "active" or "deleted"
+}

--- a/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
+++ b/src/main/java/org/example/goormssd/usermanagementbackend/service/AdminMemberService.java
@@ -243,4 +243,20 @@ public class AdminMemberService {
                 page.getTotalElements()
         );
     }
+
+
+    public void updateStatus(Long id, String status) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 회원이 존재하지 않습니다."));
+
+        if ("active".equalsIgnoreCase(status)) {
+            member.setStatus(Member.Status.ACTIVE);
+        } else if ("deleted".equalsIgnoreCase(status)) {
+            member.setStatus(Member.Status.DELETED);
+        } else {
+            throw new IllegalArgumentException("Invalid status value. Must be 'active' or 'deleted'.");
+        }
+
+        memberRepository.save(member);
+    }
 }


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 관리자 회원 상태 변경 기능 구현

---

## 📌 작업 내용 요약

- 관리자 전용 회원 상태 변경 API(PATCH /api/admin/users/status/{id}) 구현
- 요청 바디로 "active" 또는 "deleted"를 받아 상태를 변경
- Swagger 문서 주석 추가
- 잘못된 상태값이나 존재하지 않는 유저에 대한 예외 처리 포함

---

## ✅ 체크리스트

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #14

---

## 📎 기타 참고 사항

- 프론트엔드에서 유저 테이블의 user.id를 활용해 상태 변경 요청 가능
- 향후 상태 변경 히스토리 로그 기능이 필요할 수 있음
